### PR TITLE
#23 When scrolling the list of votes, the items begin moving to the right 

### DIFF
--- a/Source/Extension.Voting/src/votingPage/votingPageController.ts
+++ b/Source/Extension.Voting/src/votingPage/votingPageController.ts
@@ -485,7 +485,7 @@ export class VotingPageController extends Vue {
 
                 $(cellTitle).text('');
                 $(cellTitle).append(`<div class="work-item-color ${cssClass}-color"></div>`);
-                $(cellTitle).append(`<span>${title}</span>`);
+                $(cellTitle).append(`<span> ${title}</span>`);
                 $(cellAssignedTo).text(assignedTo);
 
                 var voteUpButton = $(cellAddButton).find('span > span.icon');

--- a/Source/Extension.Voting/src/votingPage/votingPageController.ts
+++ b/Source/Extension.Voting/src/votingPage/votingPageController.ts
@@ -484,8 +484,8 @@ export class VotingPageController extends Vue {
                 var assignedTo = parseEmail($(cellAssignedTo).text());
 
                 $(cellTitle).text('');
-                $(cellTitle).append('<div class="work-item-color ' + cssClass + '-color">&nbsp;</div>');
-                $(cellTitle).append('<span>' + title + '</span>');
+                $(cellTitle).append(`<div class="work-item-color ${cssClass}-color"></div>`);
+                $(cellTitle).append(`<span>${title}</span>`);
                 $(cellAssignedTo).text(assignedTo);
 
                 var voteUpButton = $(cellAddButton).find('span > span.icon');


### PR DESCRIPTION
Unnecessary whitespace symbol removed

PS: Please mind and merge #30 before!!!

Tested: Chrome, FireFox