### PR TITLE
#22 separate logic of "vote multiple items" and "vote items multitiple"

### DIFF
--- a/Source/Extension.Voting/src/adminPage/adminPage.html
+++ b/Source/Extension.Voting/src/adminPage/adminPage.html
@@ -65,7 +65,7 @@
                 </div>
 
                 <div class="form-group" v-if="actualVoting.isMultipleVotingEnabled">
-                    <label>Limit votes per item</label>
+                    <label>Limit votes per work item</label>
                     <input type="number" class="form-control" name="voteLimit" min="1" v-model="actualVoting.voteLimit" @change="validateInput">
                 </div>
             </div>

--- a/Source/Extension.Voting/src/adminPage/adminPage.html
+++ b/Source/Extension.Voting/src/adminPage/adminPage.html
@@ -52,14 +52,21 @@
                     </select>
                 </div>
 
+                <div class="form-group">
+                        <label>Votes per user</label>
+                        <input type="number" class="form-control" name="numberOfVotes" min="1" v-model="actualVoting.numberOfVotes" @change="validateInput">
+                </div>
+
                 <div class="checkbox">
-                    <label><input type="checkbox" name="multipleVotes" v-model="actualVoting.isMultipleVotingEnabled" @change="isMultipleVotingEnabledChanged">
-                        Multiple votes per item</span></label>
+                    <label>
+                        <input type="checkbox" name="multipleVotes" v-model="actualVoting.isMultipleVotingEnabled" @change="isMultipleVotingEnabledChanged">
+                        <span>Multiple votes per item</span>
+                    </label>
                 </div>
 
                 <div class="form-group" v-if="actualVoting.isMultipleVotingEnabled">
-                    <label>Votes per item</label>
-                    <input type="text" class="form-control" name="numberOfVotes" v-model="actualVoting.numberOfVotes">
+                    <label>Limit votes per item</label>
+                    <input type="number" class="form-control" name="voteLimit" min="1" v-model="actualVoting.voteLimit" @change="validateInput">
                 </div>
             </div>
 

--- a/Source/Extension.Voting/src/adminPage/adminPage.html
+++ b/Source/Extension.Voting/src/adminPage/adminPage.html
@@ -60,7 +60,7 @@
                 <div class="checkbox">
                     <label>
                         <input type="checkbox" name="multipleVotes" v-model="actualVoting.isMultipleVotingEnabled" @change="isMultipleVotingEnabledChanged">
-                        <span>Multiple votes per item</span>
+                        <span>Multiple votes per work item</span>
                     </label>
                 </div>
 

--- a/Source/Extension.Voting/src/adminPage/adminPageController.ts
+++ b/Source/Extension.Voting/src/adminPage/adminPageController.ts
@@ -59,9 +59,14 @@ export class AdminPageController extends Vue {
         ev.preventDefault();
     }
 
+    public validateInput() {
+        this.actualVoting.voteLimit = Math.max(1, this.actualVoting.voteLimit);
+        this.actualVoting.numberOfVotes = Math.max(1, this.actualVoting.numberOfVotes);
+    }
+
     public isMultipleVotingEnabledChanged() {
-        if (this.actualVoting.isMultipleVotingEnabled && this.actualVoting.numberOfVotes === 1) {
-            this.actualVoting.numberOfVotes = 3;
+        if (!this.actualVoting.isMultipleVotingEnabled) {
+            this.actualVoting.voteLimit = 1;
         }
     }
 

--- a/Source/Extension.Voting/src/adminPage/adminPageService.ts
+++ b/Source/Extension.Voting/src/adminPage/adminPageService.ts
@@ -46,8 +46,7 @@ export class AdminPageService extends BaseDataService {
         // this is necessary because Vue overwrites the property prototypes and JSON.stringify causes an error because of circular dependencies
         doc.voting = <Voting>Object.assign({}, voting);         
 
-        if (doc.voting.isMultipleVotingEnabled !== voting.isMultipleVotingEnabled
-            || doc.voting.level !== voting.level
+        if (doc.voting.level !== voting.level
             || doc.voting.numberOfVotes !== voting.numberOfVotes) {
             doc.vote = [];
         }

--- a/Source/Extension.Voting/src/entities/voting.ts
+++ b/Source/Extension.Voting/src/entities/voting.ts
@@ -1,9 +1,10 @@
 ﻿export class Voting {
     public description = "";
     public isVotingEnabled = false;
-    public numberOfVotes: number = 3; 
+    public numberOfVotes: number = 3;
+    public voteLimit: number = 1;
+    public isMultipleVotingEnabled: boolean = true;
     public isVotingPaused = false;
-    public isMultipleVotingEnabled = false;
     public group = "Team";
     public team: string;
     public level: string;

--- a/Source/Extension.Voting/src/services/votingDataService.ts
+++ b/Source/Extension.Voting/src/services/votingDataService.ts
@@ -39,7 +39,7 @@ export class VotingDataService {
             }
 
             voting.isVotingEnabled = voting.hasOwnProperty('votingEnabled') ? (<any>voting).votingEnabled === "true" : voting.isVotingEnabled;
-            voting.isMultipleVotingEnabled = voting.hasOwnProperty('multipleVoting') ? (<any>voting).multipleVoting === "true" : voting.isMultipleVotingEnabled;
+            //voting.isMultipleVotingEnabled = voting.hasOwnProperty('multipleVoting') ? (<any>voting).multipleVoting === "true" : voting.isMultipleVotingEnabled;
 
             return doc;
         } catch (err) {

--- a/Source/Extension.Voting/src/votingPage/votingPage.html
+++ b/Source/Extension.Voting/src/votingPage/votingPage.html
@@ -39,7 +39,7 @@
                     <p v-else>You have no votes left</p>
                 </div>
                 <div id="voteLimitDiv" class="col-sm-2">
-                        <p>Vote limit per item: {{ actualVoting.voteLimit }}</p>
+                        <p>Vote limit per work item: {{ actualVoting.voteLimit }}</p>
                 </div>
                 <div id="informationDiv" class="col-sm-12">
                     <p v-if="actualVoting != null">{{ actualVoting.description }}</p>

--- a/Source/Extension.Voting/src/votingPage/votingPage.html
+++ b/Source/Extension.Voting/src/votingPage/votingPage.html
@@ -32,11 +32,14 @@
                 <div id="titleDiv" class="col-sm-6 titleBar">
                     <p v-if="actualVoting != null">{{ actualVoting.title }}</p>
                 </div>
-                <div id="remainingVotesDiv" class="col-sm-2 col-sm-offset-4">
-                    <p v-if="actualVoting.isMultipleVotingEnabled && remainingVotes > 1">You have {{ remainingVotes }}
+                <div id="remainingVotesDiv" class="col-sm-2 col-sm-offset-2">
+                    <p v-if="remainingVotes > 1">You have {{ remainingVotes }}
                         votes left</p>
                     <p v-else-if="remainingVotes === 1">You have 1 vote left</p>
                     <p v-else>You have no votes left</p>
+                </div>
+                <div id="voteLimitDiv" class="col-sm-2">
+                        <p>Vote limit per item: {{ actualVoting.voteLimit }}</p>
                 </div>
                 <div id="informationDiv" class="col-sm-12">
                     <p v-if="actualVoting != null">{{ actualVoting.description }}</p>

--- a/Source/Extension.Voting/src/votingPage/votingPageController.ts
+++ b/Source/Extension.Voting/src/votingPage/votingPageController.ts
@@ -55,6 +55,7 @@ export class VotingPageController extends Vue {
             this.calculating();
             this.calculateMyVotes();
         };
+        this.votingService.getVoteItem = (id: number) => this.actualVotingItem(id);
         this.votingService.getActualVotingItems = () => this.actualVotingItems;
 
         this.initializeVotingpageAsync();
@@ -111,7 +112,7 @@ export class VotingPageController extends Vue {
         voteDown.parentElement.classList.add("hide");
 
         if (this.remainingVotes > 0) {
-            if (votingItem.myVotes === 0 || this.actualVoting.isMultipleVotingEnabled) {
+            if (votingItem.myVotes < this.actualVoting.voteLimit) {
                 voteUp.parentElement.classList.remove("hide");
             }
         }
@@ -187,7 +188,7 @@ export class VotingPageController extends Vue {
     }
 
     private calculating() {
-        this.remainingVotes = this.actualVoting.isMultipleVotingEnabled ? this.actualVoting.numberOfVotes : 1;
+        this.remainingVotes = this.actualVoting.numberOfVotes;
         this.myVotes = new Array<Vote>();
         this.allVotes = new Array<Vote>();
 
@@ -198,7 +199,7 @@ export class VotingPageController extends Vue {
 
     private calculateMyVotes() {
         const userVotes = {};
-        const numberOfVotes = this.actualVoting.isMultipleVotingEnabled ? this.actualVoting.numberOfVotes : 1;
+        const numberOfVotes = this.actualVoting.numberOfVotes;
 
         this.actualVotingItems = new Array<VotingItem>();
 

--- a/Source/Extension.Voting/src/votingPage/votingPageService.ts
+++ b/Source/Extension.Voting/src/votingPage/votingPageService.ts
@@ -20,6 +20,7 @@ export class VotingPageService extends BaseDataService {
     public nothingToVote: (isThereAnythingToVote: boolean) => void;
     public numberOfMyVotes: () => number;
     public calculating: () => void;
+    public getVoteItem: (id: number) => VotingItem;
     public getActualVotingItems: () => VotingItem[];
 
     constructor() {
@@ -141,29 +142,22 @@ export class VotingPageService extends BaseDataService {
     public async saveVoteAsync(vote: Vote, numberOfVotes: number) {
         const doc = await this.votingDataService.getDocumentAsync(this.documentId);
 
+        const voteItem = this.getVoteItem(vote.workItemId)
         const voting = doc.voting;
         const isEnabled = voting.isVotingEnabled;
         const isPaused = voting.isVotingPaused;
 
         if (isEnabled && !isPaused) {
-            let multipleVotes = doc.vote.some(v => v.userId === vote.userId
-                && v.votingId === vote.votingId
-                && v.workItemId === vote.workItemId);
-
             if ((numberOfVotes - this.numberOfMyVotes()) < 1) {
                 bsNotify("warning", "You have no vote remaining. \nPlease refresh your browser window to get the actual content.");
-                return;
+            } else if (voteItem.myVotes >= voting.voteLimit) {
+                bsNotify("warning", `This item is on the vote limit of ${voting.voteLimit}. \nPlease refresh your browser window to get the actual content.`);
             } else {
-                if (!voting.isMultipleVotingEnabled && multipleVotes) {
-                    bsNotify("warning", "You cannot vote again for this item. Please refresh your browser window to get the actual content.");
-                    return;
-                } else {
-                    doc.vote.push(vote);
-                    const uDoc = await this.votingDataService.updateDocumentAsync(doc);
-                    LogExtension.log("saveVote: document updated", uDoc.id);
+                doc.vote.push(vote);
+                const uDoc = await this.votingDataService.updateDocumentAsync(doc);
+                LogExtension.log("saveVote: document updated", uDoc.id);
 
-                    bsNotify("success", "Your vote has been saved.");
-                }
+                bsNotify("success", "Your vote has been saved.");
             }
         } else if (!isEnabled) {
             bsNotify("warning", "This voting has been stopped. \nPlease refresh your browser window to get the actual content.");

--- a/Source/Extension.Voting/src/votingPage/votingPageService.ts
+++ b/Source/Extension.Voting/src/votingPage/votingPageService.ts
@@ -151,7 +151,7 @@ export class VotingPageService extends BaseDataService {
             if ((numberOfVotes - this.numberOfMyVotes()) < 1) {
                 bsNotify("warning", "You have no vote remaining. \nPlease refresh your browser window to get the actual content.");
             } else if (voteItem.myVotes >= voting.voteLimit) {
-                bsNotify("warning", `This item is on the vote limit of ${voting.voteLimit}. \nPlease refresh your browser window to get the actual content.`);
+                bsNotify("warning", `This work item is on the vote limit of ${voting.voteLimit}. \nPlease refresh your browser window to get the actual content.`);
             } else {
                 doc.vote.push(vote);
                 const uDoc = await this.votingDataService.updateDocumentAsync(doc);


### PR DESCRIPTION
- Now the user can have more than one vote, but the voting for each item can be limited.

Example1: 
- User has 3 votes
- Vote limit is 1
The user may vote for 3 Items, but only once.

Example2:
- User has 3 votes
- Vote limit is 3
The user may vote for up to 3 items or put up to all his votes to one single item.

Example3:
- User has 5 votes
-Vote limit is 3
The user may vote for up to 5 items or put up to 3 votes to one single item, but the rest to others.

PS: The checkbox "Multiple votes per item" is almost unnecessary and can be removed! A limit of 1 has the same semantic!

PS: Mind #30 

PS: Is an item limiter required?!