### PR TITLE
Voting types - Issue #27

### DIFF
--- a/Source/Extension.Voting/src/adminPage/adminPage.html
+++ b/Source/Extension.Voting/src/adminPage/adminPage.html
@@ -55,17 +55,24 @@
                         </select>
                     </div>
 
-                    <div class="form-group col-md-8" v-show="isLevel" >
-                        <label>Vote on level</label>
+                    <div class="form-group col-md-8" v-show="isBacklogBased">
+                        <label>Vote on Backlog</label>
                         <select class="form-control" name="level" v-model="actualVoting.level">
-                            <option v-for="level in levels">{{ level }}</option>
+                            <option v-for="level in levels" v-bind:value="level.id">{{ level.name }}</option>
                         </select>
                     </div>
 
-                    <div class="form-group col-md-8" v-show="isQuery">
-                        <label>Vote on query</label>
+                    <div class="form-group col-md-8" v-show="isItemBased">
+                        <label>Vote on WorkItemType</label>
+                        <select class="form-control" name="item" v-model="actualVoting.item">
+                            <option v-for="item in items">{{ item }}</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group col-md-8" v-show="isQueryBased">
+                        <label>Vote on Query</label>
                         <select class="form-control" name="query" v-model="actualVoting.query">
-                            <option v-for="query in queries" v-bind:value="query.id">{{ query.path }}</option>
+                            <option v-for="query in queries" v-bind:value="query.id">{{ query.name }}</option>
                         </select>
                     </div>
                 </div>

--- a/Source/Extension.Voting/src/adminPage/adminPage.html
+++ b/Source/Extension.Voting/src/adminPage/adminPage.html
@@ -23,7 +23,7 @@
             </div>
 
             <div class="row">
-                <div id="no-permissions" class="error-message col-sm-4" v-bind:class="{ hide: userIsAdmin }">
+                <div id="no-permissions" class="error-message col-sm-4" v-show="!userIsAdmin">
                     <span>You do not have the required permissions to perform any action.</span>
                 </div>
             </div>
@@ -32,7 +32,7 @@
                 <div id="menueBar-container" class="toolbar col-sm-12 hide" style="padding-right:30px"></div>
             </div>
 
-            <div id="content" style="padding-top: 10px;" class="row container" v-bind:class="{ hide: !showContent }">
+            <div id="content" style="padding-top: 10px;" class="row container" v-show="showContent">
                 <div class="form-group">Changing the voting level or multiple votes per item will reset the votes.</div>
 
                 <div class="form-group">
@@ -42,70 +42,50 @@
 
                 <div class="form-group">
                     <label>Description</label>
-                    <input type="text" class="form-control" name="description" v-model="actualVoting.description">
+                    <input type="text" class="form-control" name="description" v-model="actualVoting.description" />
                 </div>
 
-                <div class="form-group">
-                    <label>Voting level</label>
-                    <select class="form-control" name="level" v-model="actualVoting.level">
-                        <option v-for="value in levels">{{ value }}</option>
-                    </select>
+                <hr />
+
+                <div class="row">
+                    <div class="form-group col-md-4">
+                        <label>Type</label>
+                        <select class="form-control" name="type" v-model="actualVoting.type" @change="updateVotingType">
+                            <option v-for="type in types">{{ type }}</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group col-md-8" v-show="isLevel" >
+                        <label>Vote on level</label>
+                        <select class="form-control" name="level" v-model="actualVoting.level">
+                            <option v-for="level in levels">{{ level }}</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group col-md-8" v-show="isQuery">
+                        <label>Vote on query</label>
+                        <select class="form-control" name="query" v-model="actualVoting.query">
+                            <option v-for="query in queries" v-bind:value="query.id">{{ query.path }}</option>
+                        </select>
+                    </div>
                 </div>
 
-                <div class="checkbox">
-                    <label><input type="checkbox" name="multipleVotes" v-model="actualVoting.isMultipleVotingEnabled" @change="isMultipleVotingEnabledChanged">
-                        Multiple votes per item</span></label>
-                </div>
+                <hr/>
 
-                <div class="form-group" v-if="actualVoting.isMultipleVotingEnabled">
-                    <label>Votes per item</label>
-                    <input type="text" class="form-control" name="numberOfVotes" v-model="actualVoting.numberOfVotes">
+                <div class="row">
+                    <div class="form-group col-sm-12">
+                        <label>
+                            <input type="checkbox" name="multipleVotes" v-model="actualVoting.isMultipleVotingEnabled" @change="isMultipleVotingEnabledChanged">
+                            Multiple votes per item
+                        </label>
+                        <input type="text" class="form-control" name="numberOfVotes" v-model="actualVoting.numberOfVotes" v-show="actualVoting.isMultipleVotingEnabled">
+                    </div>
                 </div>
             </div>
 
             <div class="row" style="padding-top: 10px;">
                 <div class="col-sm-12" id="errorMessage" v-bind:class="{ hide: showContent }">
                     <p id="votingdisabledmessage">There is no voting available. Please create a new voting.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="modal fade" id="excludeModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-            <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                        <h4 class="modal-title" id="myModalLabel">Included work item types</h4>
-                    </div>
-                    <div class="modal-body">
-                        <div id="includeList" class="panel panel-default pull-left" style="width:45%">
-                            <div class="panel-heading">Included work item types</div>
-                            <div class="panel-body" id="includeListbody" v-on:drop="addToIncludes" v-on:dragover="onDragOver">
-                                <div name="itemPanel" class="panel panel-default" draggable="true" v-on:dragstart="startDrag" v-for="item in levels"
-                                    v-bind:id="item.replace(/\s+/g, '')">
-                                    <div class="panel-body">
-                                        {{ item }}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div id="excludeList" class="panel panel-default pull-right" style="width:45%">
-                            <div class="panel-heading">Excluded work item types</div>
-                            <div class="panel-body" id="excludeListbody" v-on:drop="addToExcludes" v-on:dragover="onDragOver">
-                                <div name="itemPanel" class="panel panel-default" draggable="true" v-on:dragstart="startDrag" v-for="item in adminPageService.excludes"
-                                    v-bind:id="item.replace(/\s+/g, '')">
-                                    <div class="panel-body">
-                                        {{ item }}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="clearfix"></div>
-                    </div>
                 </div>
             </div>
         </div>

--- a/Source/Extension.Voting/src/adminPage/adminPage.html
+++ b/Source/Extension.Voting/src/adminPage/adminPage.html
@@ -43,12 +43,12 @@
                 <div id="content" style="padding-top: 10px;" class="row container" v-show="showContent">
                     <div class="form-group">Changing the voting level or multiple votes per item will reset the votes.</div>
 
-                    <div class="form-group" data-toggle="tooltip" title="Set an authentic title for this vote session. (required)">
+                    <div class="form-group" data-toggle="tooltip" title="Enter a title for the voting.">
                         <label>Title <span class="required" v-if="actualVoting.title === ''">*</span></label>
                         <input type="text" class="form-control" v-model="actualVoting.title">
                     </div>
 
-                    <div class="form-group" data-toggle="tooltip" title="Space for further descriptions.">
+                    <div class="form-group" data-toggle="tooltip" title="Enter a description for the voting.">
                         <label>Description</label>
                         <input type="text" class="form-control" name="description" v-model="actualVoting.description" />
                     </div>
@@ -56,32 +56,32 @@
                     <hr />
 
                     <div class="row">
-                        <div class="form-group col-md-3" data-toggle="tooltip" title="Choose a type of the vote session.">
+                        <div class="form-group col-md-3" data-toggle="tooltip" title="Select a voting type. A backlog-based voting allows to vote on items of a specified backlog level. The order of the backlog items from the voting can then be applied to the backlog. A query-based voting allows to vote on work items specified by a shared (flat) query.">
                             <label>Type</label>
                             <select class="form-control" name="type" v-model="actualVoting.type" @change="updateVotingType">
                                 <option v-for="type in types">{{ type }}</option>
                             </select>
                         </div>
 
-                        <div class="form-group col-md-9" v-show="isBacklogBased" data-toggle="tooltip" title="Start a vote session to a particular backlog level.">
+                        <div class="form-group col-md-9" v-show="isBacklogBased" data-toggle="tooltip" title="Select the backlog level to vote on.">
                             <label>Vote on Backlog</label>
                             <select class="form-control" name="level" v-model="actualVoting.level">
                                 <option v-for="level in levels" v-bind:value="level.id">{{ level.name }}</option>
                             </select>
                         </div>
 
-                        <div class="form-group col-md-9" v-show="isItemBased" data-toggle="tooltip" title="Start a vote session to a particular type of Work Items.">
+                        <div class="form-group col-md-9" v-show="isItemBased" data-toggle="tooltip" title="Select the work item type to vote on.">
                             <label>Vote on WorkItemType</label>
                             <select class="form-control" name="item" v-model="actualVoting.item">
                                 <option v-for="item in items">{{ item }}</option>
                             </select>
                         </div>
 
-                        <div class="form-group col-md-9" v-show="isQueryBased" data-toggle="tooltip" title="Start a vote session to a particular shared query.">
+                        <div class="form-group col-md-9" v-show="isQueryBased" data-toggle="tooltip" title="Select the query to vote on.">
                             <label>Vote on Query</label>
                             <!--<select class="form-control" name="query" v-model="actualVoting.query">
                                 <option v-for="query in queries" v-bind:value="query.id">{{ query.name }}</option>
-                            </select>-->
+                            </select> //Could be alternatively used if the browser doesn't support the fancy stuff-->
                             <div class="form-control">
                                 <span id="query-select-button"></span>
                                 <button class="btn btn-primary dropdown-toggle pull-right" type="button" data-toggle="dropdown" style="margin: -5px -10px -5px -5px">

--- a/Source/Extension.Voting/src/adminPage/adminPage.html
+++ b/Source/Extension.Voting/src/adminPage/adminPage.html
@@ -13,6 +13,7 @@
 <body>
     <div class="hide" id="adminPage">
         <div id="waitContainerAdmin"></div>
+
         <div class="vso-container">
             <div class="row">
                 <h1 class="votingheadline">Voting settings</h1>
@@ -28,71 +29,82 @@
                 </div>
             </div>
 
+            <div class="row" style="padding-top: 10px;">
+                <div class="col-sm-12" id="errorMessage" v-show="!showContent">
+                    <p id="votingdisabledmessage">There is no voting available. Please create a new voting.</p>
+                </div>
+            </div>
+
             <div class="row">
                 <div id="menueBar-container" class="toolbar col-sm-12 hide" style="padding-right:30px"></div>
             </div>
 
-            <div id="content" style="padding-top: 10px;" class="row container" v-show="showContent">
-                <div class="form-group">Changing the voting level or multiple votes per item will reset the votes.</div>
+            <div style="overflow-y: auto; height: 80vh">
+                <div id="content" style="padding-top: 10px;" class="row container" v-show="showContent">
+                    <div class="form-group">Changing the voting level or multiple votes per item will reset the votes.</div>
 
-                <div class="form-group">
-                    <label>Title <span class="required" v-if="actualVoting.title === ''">*</span></label>
-                    <input type="text" class="form-control" v-model="actualVoting.title">
-                </div>
-
-                <div class="form-group">
-                    <label>Description</label>
-                    <input type="text" class="form-control" name="description" v-model="actualVoting.description" />
-                </div>
-
-                <hr />
-
-                <div class="row">
-                    <div class="form-group col-md-4">
-                        <label>Type</label>
-                        <select class="form-control" name="type" v-model="actualVoting.type" @change="updateVotingType">
-                            <option v-for="type in types">{{ type }}</option>
-                        </select>
+                    <div class="form-group" data-toggle="tooltip" title="Set an authentic title for this vote session. (required)">
+                        <label>Title <span class="required" v-if="actualVoting.title === ''">*</span></label>
+                        <input type="text" class="form-control" v-model="actualVoting.title">
                     </div>
 
-                    <div class="form-group col-md-8" v-show="isBacklogBased">
-                        <label>Vote on Backlog</label>
-                        <select class="form-control" name="level" v-model="actualVoting.level">
-                            <option v-for="level in levels" v-bind:value="level.id">{{ level.name }}</option>
-                        </select>
+                    <div class="form-group" data-toggle="tooltip" title="Space for further descriptions.">
+                        <label>Description</label>
+                        <input type="text" class="form-control" name="description" v-model="actualVoting.description" />
                     </div>
 
-                    <div class="form-group col-md-8" v-show="isItemBased">
-                        <label>Vote on WorkItemType</label>
-                        <select class="form-control" name="item" v-model="actualVoting.item">
-                            <option v-for="item in items">{{ item }}</option>
-                        </select>
+                    <hr />
+
+                    <div class="row">
+                        <div class="form-group col-md-3" data-toggle="tooltip" title="Choose a type of the vote session.">
+                            <label>Type</label>
+                            <select class="form-control" name="type" v-model="actualVoting.type" @change="updateVotingType">
+                                <option v-for="type in types">{{ type }}</option>
+                            </select>
+                        </div>
+
+                        <div class="form-group col-md-9" v-show="isBacklogBased" data-toggle="tooltip" title="Start a vote session to a particular backlog level.">
+                            <label>Vote on Backlog</label>
+                            <select class="form-control" name="level" v-model="actualVoting.level">
+                                <option v-for="level in levels" v-bind:value="level.id">{{ level.name }}</option>
+                            </select>
+                        </div>
+
+                        <div class="form-group col-md-9" v-show="isItemBased" data-toggle="tooltip" title="Start a vote session to a particular type of Work Items.">
+                            <label>Vote on WorkItemType</label>
+                            <select class="form-control" name="item" v-model="actualVoting.item">
+                                <option v-for="item in items">{{ item }}</option>
+                            </select>
+                        </div>
+
+                        <div class="form-group col-md-9" v-show="isQueryBased" data-toggle="tooltip" title="Start a vote session to a particular shared query.">
+                            <label>Vote on Query</label>
+                            <!--<select class="form-control" name="query" v-model="actualVoting.query">
+                                <option v-for="query in queries" v-bind:value="query.id">{{ query.name }}</option>
+                            </select>-->
+                            <div class="form-control">
+                                <span id="query-select-button"></span>
+                                <button class="btn btn-primary dropdown-toggle pull-right" type="button" data-toggle="dropdown" style="margin: -5px -10px -5px -5px">
+                                    <span class="caret"></span>
+                                </button>
+                                <div id="query-tree-container" class="dropdown-menu pull-right" style="margin: 0px 15px 0px 0px"></div>
+                            </div>
+                        </div>
                     </div>
 
-                    <div class="form-group col-md-8" v-show="isQueryBased">
-                        <label>Vote on Query</label>
-                        <select class="form-control" name="query" v-model="actualVoting.query">
-                            <option v-for="query in queries" v-bind:value="query.id">{{ query.name }}</option>
-                        </select>
+                    <hr/>
+
+                    <div class="row">
+                        <div class="form-group col-sm-12" data-toggle="tooltip" title="Enable multible votes per item.">
+                            <label>
+                                <input type="checkbox" name="multipleVotes" v-model="actualVoting.isMultipleVotingEnabled" @change="isMultipleVotingEnabledChanged">
+                                Multiple votes per item
+                            </label>
+                            <input type="text" class="form-control" name="numberOfVotes" v-model="actualVoting.numberOfVotes" v-show="actualVoting.isMultipleVotingEnabled">
+                        </div>
                     </div>
-                </div>
 
-                <hr/>
-
-                <div class="row">
-                    <div class="form-group col-sm-12">
-                        <label>
-                            <input type="checkbox" name="multipleVotes" v-model="actualVoting.isMultipleVotingEnabled" @change="isMultipleVotingEnabledChanged">
-                            Multiple votes per item
-                        </label>
-                        <input type="text" class="form-control" name="numberOfVotes" v-model="actualVoting.numberOfVotes" v-show="actualVoting.isMultipleVotingEnabled">
-                    </div>
-                </div>
-            </div>
-
-            <div class="row" style="padding-top: 10px;">
-                <div class="col-sm-12" id="errorMessage" v-bind:class="{ hide: showContent }">
-                    <p id="votingdisabledmessage">There is no voting available. Please create a new voting.</p>
+                    <div class="row" style="height: 15vh"><!--Required whitespace--></div>
                 </div>
             </div>
         </div>

--- a/Source/Extension.Voting/src/adminPage/adminPage.html
+++ b/Source/Extension.Voting/src/adminPage/adminPage.html
@@ -39,7 +39,7 @@
                 <div id="menueBar-container" class="toolbar col-sm-12 hide" style="padding-right:30px"></div>
             </div>
 
-            <div style="overflow-y: auto; height: 80vh">
+            <div id="admin-form" style="overflow-y: auto; height: 80vh">
                 <div id="content" style="padding-top: 10px;" class="row container" v-show="showContent">
                     <div class="form-group">Changing the voting level or multiple votes per item will reset the votes.</div>
 
@@ -84,7 +84,7 @@
                             </select> //Could be alternatively used if the browser doesn't support the fancy stuff-->
                             <div class="form-control">
                                 <span id="query-select-button"></span>
-                                <button class="btn btn-primary dropdown-toggle pull-right" type="button" data-toggle="dropdown" style="margin: -5px -10px -5px -5px">
+                                <button class="btn btn-primary dropdown-toggle pull-right" type="button" data-toggle="dropdown" style="margin: -5px -10px -5px -5px" @click="createQueryTree">
                                     <span class="caret"></span>
                                 </button>
                                 <div id="query-tree-container" class="dropdown-menu pull-right" style="margin: 0px 15px 0px 0px"></div>

--- a/Source/Extension.Voting/src/adminPage/adminPage.ts
+++ b/Source/Extension.Voting/src/adminPage/adminPage.ts
@@ -7,8 +7,16 @@ import { AdminPageController } from "./adminPageController";
     try {
         VSS.ready(() => {
             LogExtension.log("VSS ready");
-            new AdminPageController().$mount("#adminPage");
+            var controller = new AdminPageController().$mount("#adminPage");
             $('#appVersion').text(VSS.getExtensionContext().version);
+
+            var querySelectButton = $('#query-select-button');
+            var queryTreeContainer = $('#query-tree-container');
+
+            queryTreeContainer.bind('selectionchanged', function (e, args) {
+                querySelectButton.text(args.selectedNode.application.path);
+                controller.actualVoting.query = args.selectedNode.application.id;
+            });
         });
     } catch (ex) {
         LogExtension.log(ex);

--- a/Source/Extension.Voting/src/adminPage/adminPage.ts
+++ b/Source/Extension.Voting/src/adminPage/adminPage.ts
@@ -7,15 +7,22 @@ import { AdminPageController } from "./adminPageController";
     try {
         VSS.ready(() => {
             LogExtension.log("VSS ready");
-            var controller = new AdminPageController().$mount("#adminPage");
+            let controller = new AdminPageController().$mount("#adminPage");
             $('#appVersion').text(VSS.getExtensionContext().version);
 
-            var querySelectButton = $('#query-select-button');
-            var queryTreeContainer = $('#query-tree-container');
+            let form = $('#admin-form');
+            let querySelectButton = $('#query-select-button');
+            let queryTreeContainer = $('#query-tree-container');
 
             queryTreeContainer.bind('selectionchanged', function (e, args) {
-                querySelectButton.text(args.selectedNode.application.path);
-                controller.actualVoting.query = args.selectedNode.application.id;
+                if (args.selectedNode.application) {
+                    querySelectButton.text(args.selectedNode.application.path);
+                    controller.actualVoting.query = args.selectedNode.application.id;
+                }
+            });
+
+            window.addEventListener('resize', function () {
+                form.height(window.innerHeight * 0.9 - 100);
             });
         });
     } catch (ex) {

--- a/Source/Extension.Voting/src/adminPage/adminPageController.test.ts
+++ b/Source/Extension.Voting/src/adminPage/adminPageController.test.ts
@@ -1,6 +1,5 @@
 
 jest.mock("TFS/WorkItemTracking/RestClient", () => {});
-import { getClient as getWitClient } from "TFS/WorkItemTracking/RestClient";
 
 import { AdminPageService } from "./adminPageService";
 import { AdminPageController } from "./adminPageController";
@@ -41,6 +40,6 @@ describe('mounted', () => {
         const controller = new AdminPageController();
         controller.mounted();
 
-        adminPageServiceMock.verify(s => s.loadAsync(), typemoq.Times.atLeastOnce());
+        adminPageServiceMock.verify(s => s.loadGreedyAsync(), typemoq.Times.atLeastOnce());
     });
 });

--- a/Source/Extension.Voting/src/adminPage/adminPageService.ts
+++ b/Source/Extension.Voting/src/adminPage/adminPageService.ts
@@ -2,38 +2,10 @@
 import { LogExtension } from "../shared/logExtension";
 import { Voting } from "../entities/voting";
 import { bsNotify } from "../shared/common";
-import { VotingDocument } from "../entities/votingDocument";
-import { convertValueToDisplayString } from "VSS/Utils/Core";
 
 export class AdminPageService extends BaseDataService {
     constructor() {
         super();
-    }
-
-    public async addToExcludeAsync(item: string) {
-        if (this.excludes.indexOf(item) === -1) {
-            this.excludes.push(item);
-            this.witFieldNames.splice(this.witFieldNames.indexOf(item), 1);
-        }
-
-        const doc = await this.votingDataService.getDocumentAsync(this.documentId);
-        doc.excludes = this.excludes;
-
-        await this.votingDataService.updateDocumentAsync(doc);
-        LogExtension.log("saveVoting: document updated");
-    }
-
-    public async addToIncludeAsync(item: string) {
-        if (this.witFieldNames.indexOf(item) === -1) {
-            this.witFieldNames.push(item);
-            this.excludes.splice(this.excludes.indexOf(item), 1);
-        }
-
-        const doc = await this.votingDataService.getDocumentAsync(this.documentId);
-        doc.excludes = this.excludes;
-
-        await this.votingDataService.updateDocumentAsync(doc);
-        LogExtension.log("saveVoting: document updated");
     }
 
     public async saveVotingAsync(voting: Voting) {
@@ -41,13 +13,13 @@ export class AdminPageService extends BaseDataService {
 
         doc.id = this.documentId;
         doc.vote = doc.vote || [];
-        doc.excludes = this.excludes;
 
         // this is necessary because Vue overwrites the property prototypes and JSON.stringify causes an error because of circular dependencies
-        doc.voting = <Voting>Object.assign({}, voting);         
+        <Voting>Object.assign(doc.voting, voting);
 
         if (doc.voting.isMultipleVotingEnabled !== voting.isMultipleVotingEnabled
             || doc.voting.level !== voting.level
+            || doc.voting.query !== voting.query
             || doc.voting.numberOfVotes !== voting.numberOfVotes) {
             doc.vote = [];
         }

--- a/Source/Extension.Voting/src/entities/idToName.ts
+++ b/Source/Extension.Voting/src/entities/idToName.ts
@@ -1,0 +1,4 @@
+interface IdToName {
+    id: string,
+    name: string
+}

--- a/Source/Extension.Voting/src/entities/voting.ts
+++ b/Source/Extension.Voting/src/entities/voting.ts
@@ -1,4 +1,6 @@
-﻿export class Voting {
+﻿import { VotingTypes } from "../entities/votingTypes";
+
+export class Voting {
     public description = "";
     public isVotingEnabled = false;
     public numberOfVotes: number = 3; 
@@ -8,8 +10,21 @@
     public team: string;
     public type: string;
     public level: string;
+    public item: string;
     public query: string;
     public created: number;
     public lastModified: number;
     public title = "";
+
+    public get isBacklogBased() {
+        return this.type == VotingTypes.LEVEL;
+    }
+
+    public get isItemBased() {
+        return this.type == VotingTypes.ITEM;
+    }
+
+    public get isQueryBased() {
+        return this.type == VotingTypes.QUERY;
+    }
 }

--- a/Source/Extension.Voting/src/entities/voting.ts
+++ b/Source/Extension.Voting/src/entities/voting.ts
@@ -6,7 +6,9 @@
     public isMultipleVotingEnabled = false;
     public group = "Team";
     public team: string;
+    public type: string;
     public level: string;
+    public query: string;
     public created: number;
     public lastModified: number;
     public title = "";

--- a/Source/Extension.Voting/src/entities/votingTypes.ts
+++ b/Source/Extension.Voting/src/entities/votingTypes.ts
@@ -1,4 +1,5 @@
 export enum VotingTypes {
     LEVEL = "Backlog-based Voting",
+    ITEM = "Item-based Voting",
     QUERY = "Query-based Voting"
 }

--- a/Source/Extension.Voting/src/entities/votingTypes.ts
+++ b/Source/Extension.Voting/src/entities/votingTypes.ts
@@ -1,0 +1,4 @@
+export enum VotingTypes {
+    LEVEL = "Backlog-based Voting",
+    QUERY = "Query-based Voting"
+}

--- a/Source/Extension.Voting/src/services/baseDataService.ts
+++ b/Source/Extension.Voting/src/services/baseDataService.ts
@@ -159,8 +159,6 @@ export class BaseDataService {
                 teamId: context.team.id
             });
 
-            console.log(backlogConf);
-
             this._witLevelNames = backlogConf.portfolioBacklogs
                 .sort((a, b) => b.rank - a.rank)
                 .filter(p => !p.isHidden)
@@ -195,7 +193,7 @@ export class BaseDataService {
         async function recursiveSearch (item: QueryHierarchyItem) {
             if (item.hasOwnProperty('children')) {
                 for (let child of item.children) {
-                    recursiveSearch(child);
+                    await recursiveSearch(child);
                 }
             }
             else if (item.hasChildren) {
@@ -217,7 +215,7 @@ export class BaseDataService {
             const queries = await witClient.getQuery(projectId, "Shared Queries", QueryExpand.None);
             this._flatQueryNames = [];
             await recursiveSearch(queries);
-
+            
             LogExtension.log(this.flatQueryNames);
         } catch (error) {
             LogExtension.log(error);

--- a/Source/Extension.Voting/src/services/votingDataService.ts
+++ b/Source/Extension.Voting/src/services/votingDataService.ts
@@ -1,5 +1,6 @@
 ﻿import { VotingDocument } from "../entities/votingDocument";
 import { LogExtension } from "../shared/logExtension";
+import { VotingTypes } from "../entities/votingTypes";
 
 export class VotingDataService {
     private webContext: WebContext;
@@ -35,11 +36,12 @@ export class VotingDataService {
                     if (voting.lastModified < doc.voting[i].lastModified) {
                         voting = doc.voting[i];
                     }
-                }                
+                }
             }
 
             voting.isVotingEnabled = voting.hasOwnProperty('votingEnabled') ? (<any>voting).votingEnabled === "true" : voting.isVotingEnabled;
             voting.isMultipleVotingEnabled = voting.hasOwnProperty('multipleVoting') ? (<any>voting).multipleVoting === "true" : voting.isMultipleVotingEnabled;
+            voting.type = voting.type || VotingTypes.LEVEL;
 
             return doc;
         } catch (err) {

--- a/Source/Extension.Voting/src/votingPage/votingPage.html
+++ b/Source/Extension.Voting/src/votingPage/votingPage.html
@@ -70,25 +70,25 @@
                 </div>
             </div>
 
-            <div class="row">
-                <div id="grid-container" class="col-sm-12" v-bind:class="{ hide: status !== 1 && status !== 2 }">
-                </div>
+            <div id="nothingToVote" class="col-sm-12" v-bind:class="{ hide: status !== 3 }">
+                <div class="hub-no-content-gutter gutter-banner">
+                    <div class="gutter-banner-container">
+                        <div class="gutter-banner-text">
+                            <h2 class="votingh2">It's lonely in here!</h2>
+                            <p>There is nothing to vote for...</p>
+                        </div>
 
-                <div id="nothingToVote" class="col-sm-12" v-bind:class="{ hide: status !== 3 }">
-                    <div class="hub-no-content-gutter gutter-banner">
-                        <div class="gutter-banner-container">
-                            <div class="gutter-banner-text">
-                                <h2 class="votingh2">It's lonely in here!</h2>
-                                <p>There is nothing to vote for...</p>
-                            </div>
-
-                            <div class="gutter-banner-icon">
-                                <div class="image image-vso-cloud"></div>
-                            </div>
+                        <div class="gutter-banner-icon">
+                            <div class="image image-vso-cloud"></div>
                         </div>
                     </div>
                 </div>
             </div>
+
+            <div class="row">
+                <div id="grid-container" class="col-sm-12" v-bind:class="{ hide: status !== 1 && status !== 2 }"></div>
+            </div>
+
         </div>
     </div>
 

--- a/Source/Extension.Voting/src/votingPage/votingPageController.ts
+++ b/Source/Extension.Voting/src/votingPage/votingPageController.ts
@@ -159,8 +159,18 @@ export class VotingPageController extends Vue {
             await this.votingService.getAreasAsync();
 
             LogExtension.log("loadWorkItems");
-            let id = this.actualVoting.type == VotingTypes.LEVEL ? this.actualVoting.level : this.actualVoting.query;
-            await this.votingService.loadWorkItemsAsync(id, this.actualVoting.type);
+
+            switch (this.actualVoting.type) {
+                case VotingTypes.LEVEL:
+                    await this.votingService.loadWorkItemsByTypes(this.actualVoting.level);
+                    break;
+                case VotingTypes.QUERY:
+                    await this.votingService.loadWorkItemsByQuery(this.actualVoting.query);
+                    break;
+                default:
+                    LogExtension.log("error:", "Unknown VotingType!");
+                    return;
+            }
 
             const hasAcceptedDataProtection = this.cookieService.isCookieSet();
             if (hasAcceptedDataProtection) {

--- a/Source/Extension.Voting/src/votingPage/votingPageController.ts
+++ b/Source/Extension.Voting/src/votingPage/votingPageController.ts
@@ -427,7 +427,7 @@ export class VotingPageController extends Vue {
         const that = this;
 
         this.grid = controls.create(grids.Grid, $("#grid-container"), {
-            height: "400px",
+            height: "70vh",
             allowMultiSelect: false,
             columns: [
                 {
@@ -461,7 +461,7 @@ export class VotingPageController extends Vue {
                 },
                 { tooltip: "Work Item ID", text: "ID", index: "id", width: 50, fieldId: "itemId" },
                 { tooltip: "Work Item Type", text: "Work Item Type", index: "workItemType", width: 100 },
-                { tooltip: "Work Item Title", text: "Title", index: "title", width: 650 },
+                { tooltip: "Work Item Title", text: "Title", index: "title", width: 600 },
                 { tooltip: "Assigned team member", text: "Assigned To", index: "assignedTo", width: 125 },
                 { tooltip: "Work Item State", text: "State", index: "state", width: 100 },
                 { tooltip: "All votes per item", text: "Votes", index: "allVotes", width: 60 },
@@ -518,6 +518,7 @@ export class VotingPageController extends Vue {
         });
 
         observer.observe(document.getElementById('grid-container'), { childList: true, subtree: true });
+        $('#grid-container').append("<div style='height: 20vh'><!--Whitespace--></div>");
     }
 
     private generateTeamPivot() {

--- a/Source/Extension.Voting/src/votingPage/votingPageController.ts
+++ b/Source/Extension.Voting/src/votingPage/votingPageController.ts
@@ -132,19 +132,20 @@ export class VotingPageController extends Vue {
             this.generateTeamPivot();
             this.updateTeam(this.votingService.team);
 
-            await this.refreshAsync(true);
         } finally {
             this.waitControl.endWait();
         }
+        await this.refreshAsync(true);
     }
 
-    private async refreshAsync(lazy?: boolean) {
+    private async refreshAsync(lazy: boolean = false) {
         this.waitControl.startWait();
 
         try {
             if (!lazy) {
                 LogExtension.log("reloadVoting");
                 <Voting>Object.assign(this.actualVoting, await this.votingService.loadVotingAsync()); //assign keeps bindings!!!
+                this.createVotingMenue();
             }
             this.setStatus();
 
@@ -341,6 +342,7 @@ export class VotingPageController extends Vue {
     }
 
     private createVotingMenue() {
+        $("#votingMenue-container").text("");
         controls.create(menus.MenuBar, $("#votingMenue-container"), {
             showIcon: true,
             items: [


### PR DESCRIPTION
New Features:
Refers #27 

2 Voting types - "Backlog-based" and "Query-based".
Use "Backlog-based" to vote on Backlog-Level (e.g. Epics, Features, Requirements) depending on the project settings.
Use "Query-based" to vote on a subset. Create a query first and employ it in the voting settings.
(Only flat queries are supported)
Beware: Only Backlog-Based votings can be applied to backlog!

Tooltips for all settings.

Bugs solved:
Voting Settings lost its bindings after saving: fixed.
Voting Setting now Scrollable.